### PR TITLE
Allow non-root OIDC issuer

### DIFF
--- a/jwt-authorizer/src/oidc.rs
+++ b/jwt-authorizer/src/oidc.rs
@@ -11,7 +11,7 @@ pub struct OidcDiscovery {
 pub async fn discover_jwks(issuer: &str) -> Result<String, InitError> {
     let discovery_url = reqwest::Url::parse(issuer)
         .map_err(|e| InitError::DiscoveryError(e.to_string()))?
-        .join("/.well-known/openid-configuration")
+        .join(".well-known/openid-configuration")
         .map_err(|e| InitError::DiscoveryError(e.to_string()))?;
     reqwest::Client::new()
         .get(discovery_url)


### PR DESCRIPTION
My OIDC endpoint is not at the root and I couldn't use `discover_jwks` via `from_oidc` because it would strip the path of the issuer.

Before:
```
issuer: 'https://example.com/myissuer/'
result: 'https://example.com/.well-known/openid-configuration'
```

After:
```
issuer: 'https://example.com/myissuer/'
result: 'https://example.com/myissuer/.well-known/openid-configuration'
```

I checked, and having the discovery url not at the root seems to be supported by the standard:

https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationRequest