### PR TITLE
Remove `'static` lifetime requirement

### DIFF
--- a/jwt-authorizer/src/authorizer.rs
+++ b/jwt-authorizer/src/authorizer.rs
@@ -51,7 +51,7 @@ pub enum KeySourceType {
     RSA(String),
     EC(String),
     ED(String),
-    Secret(&'static str),
+    Secret(String),
     Jwks(String),
     JwksString(String), // TODO: expose JwksString in JwtAuthorizer or remove it
     Discovery(String),
@@ -180,7 +180,7 @@ mod tests {
     #[tokio::test]
     async fn build_from_secret() {
         let h = Header::new(Algorithm::HS256);
-        let a = Authorizer::<Value>::build(&KeySourceType::Secret("xxxxxx"), None, None, Validation::new())
+        let a = Authorizer::<Value>::build(&KeySourceType::Secret("xxxxxx".to_owned()), None, None, Validation::new())
             .await
             .unwrap();
         let k = a.key_source.get_key(h);

--- a/jwt-authorizer/src/layer.rs
+++ b/jwt-authorizer/src/layer.rs
@@ -50,7 +50,7 @@ where
     }
 
     /// Builds Authorizer Layer from a JWKS endpoint
-    pub fn from_jwks_url(url: &'static str) -> JwtAuthorizer<C> {
+    pub fn from_jwks_url(url: &str) -> JwtAuthorizer<C> {
         JwtAuthorizer {
             key_source_type: KeySourceType::Jwks(url.to_owned()),
             refresh: Default::default(),
@@ -60,7 +60,7 @@ where
     }
 
     /// Builds Authorizer Layer from a RSA PEM file
-    pub fn from_rsa_pem(path: &'static str) -> JwtAuthorizer<C> {
+    pub fn from_rsa_pem(path: &str) -> JwtAuthorizer<C> {
         JwtAuthorizer {
             key_source_type: KeySourceType::RSA(path.to_owned()),
             refresh: Default::default(),
@@ -70,7 +70,7 @@ where
     }
 
     /// Builds Authorizer Layer from a EC PEM file
-    pub fn from_ec_pem(path: &'static str) -> JwtAuthorizer<C> {
+    pub fn from_ec_pem(path: &str) -> JwtAuthorizer<C> {
         JwtAuthorizer {
             key_source_type: KeySourceType::EC(path.to_owned()),
             refresh: Default::default(),
@@ -80,7 +80,7 @@ where
     }
 
     /// Builds Authorizer Layer from a EC PEM file
-    pub fn from_ed_pem(path: &'static str) -> JwtAuthorizer<C> {
+    pub fn from_ed_pem(path: &str) -> JwtAuthorizer<C> {
         JwtAuthorizer {
             key_source_type: KeySourceType::ED(path.to_owned()),
             refresh: Default::default(),
@@ -90,9 +90,9 @@ where
     }
 
     /// Builds Authorizer Layer from a secret phrase
-    pub fn from_secret(secret: &'static str) -> JwtAuthorizer<C> {
+    pub fn from_secret(secret: &str) -> JwtAuthorizer<C> {
         JwtAuthorizer {
-            key_source_type: KeySourceType::Secret(secret),
+            key_source_type: KeySourceType::Secret(secret.to_owned()),
             refresh: Default::default(),
             claims_checker: None,
             validation: None,


### PR DESCRIPTION
In some cases, the static lifetime can be problematic because it prevents

* Load key from the configuration file (or other dynamically loaded value) without involving `Box::leak()`

To address the problem, it is advised to remove `'static` lifetime requirement and clone the value as needed.