### PR TITLE
feat: working but naive implementation of named cookie as jwt source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7efb37c3e1ccb1ff97164ad95ac1606e8ccd35b3fa0a7d99a304c7f4a428cc24"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,6 +751,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tower",
+ "tower-cookies",
  "tower-http",
  "tower-layer",
  "tower-service",
@@ -1558,6 +1570,23 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-cookies"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40f38d941a2ffd8402b36e02ae407637a9caceb693aaf2edc910437db0f36984"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "cookie",
+ "futures-util",
+ "http",
+ "parking_lot",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/demo-server/src/main.rs
+++ b/demo-server/src/main.rs
@@ -5,6 +5,7 @@ use std::net::SocketAddr;
 use tower_http::trace::TraceLayer;
 use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+use jwt_authorizer::layer::JwtSource;
 
 mod oidc_provider;
 
@@ -49,7 +50,7 @@ async fn main() -> Result<(), InitError> {
     let api = Router::new()
         .route("/protected", get(protected))
         // adding the authorizer layer
-        .layer(jwt_auth.layer().await?);
+        .layer(jwt_auth.layer(JwtSource::Bearer).await?);
 
     let app = Router::new()
         // public endpoint

--- a/demo-server/src/main.rs
+++ b/demo-server/src/main.rs
@@ -5,7 +5,6 @@ use std::net::SocketAddr;
 use tower_http::trace::TraceLayer;
 use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
-use jwt_authorizer::layer::JwtSource;
 
 mod oidc_provider;
 
@@ -50,7 +49,7 @@ async fn main() -> Result<(), InitError> {
     let api = Router::new()
         .route("/protected", get(protected))
         // adding the authorizer layer
-        .layer(jwt_auth.layer(JwtSource::Bearer).await?);
+        .layer(jwt_auth.layer().await?);
 
     let app = Router::new()
         // public endpoint

--- a/jwt-authorizer/Cargo.toml
+++ b/jwt-authorizer/Cargo.toml
@@ -25,6 +25,7 @@ tokio = { version = "1.25", features = ["full"] }
 tower-http = { version = "0.4", features = ["trace", "auth"] }
 tower-layer = "0.3"
 tower-service = "0.3"
+tower-cookies = "0.9.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/jwt-authorizer/src/layer.rs
+++ b/jwt-authorizer/src/layer.rs
@@ -33,6 +33,7 @@ where
     refresh: Option<Refresh>,
     claims_checker: Option<FnClaimsChecker<C>>,
     validation: Option<Validation>,
+    pub jwt_source: JwtSource,
 }
 
 /// authorization layer builder
@@ -47,6 +48,7 @@ where
             refresh: Default::default(),
             claims_checker: None,
             validation: None,
+            jwt_source: JwtSource::Bearer,
         }
     }
 
@@ -57,6 +59,7 @@ where
             refresh: Default::default(),
             claims_checker: None,
             validation: None,
+            jwt_source: JwtSource::Bearer,
         }
     }
 
@@ -67,6 +70,7 @@ where
             refresh: Default::default(),
             claims_checker: None,
             validation: None,
+            jwt_source: JwtSource::Bearer,
         }
     }
 
@@ -77,6 +81,7 @@ where
             refresh: Default::default(),
             claims_checker: None,
             validation: None,
+            jwt_source: JwtSource::Bearer,
         }
     }
 
@@ -87,6 +92,7 @@ where
             refresh: Default::default(),
             claims_checker: None,
             validation: None,
+            jwt_source: JwtSource::Bearer,
         }
     }
 
@@ -97,6 +103,7 @@ where
             refresh: Default::default(),
             claims_checker: None,
             validation: None,
+            jwt_source: JwtSource::Bearer,
         }
     }
 
@@ -135,11 +142,17 @@ where
         self
     }
 
+    pub fn with_jwt_source(mut self, src: JwtSource) -> JwtAuthorizer<C> {
+        self.jwt_source = src;
+
+        self
+    }
+
     /// Build axum layer
-    pub async fn layer(self, jwt_source: JwtSource) -> Result<AsyncAuthorizationLayer<C>, InitError> {
+    pub async fn layer(self) -> Result<AsyncAuthorizationLayer<C>, InitError> {
         let val = self.validation.unwrap_or_default();
         let auth = Arc::new(Authorizer::build(&self.key_source_type, self.claims_checker, self.refresh, val).await?);
-        Ok(AsyncAuthorizationLayer::new(auth, jwt_source))
+        Ok(AsyncAuthorizationLayer::new(auth, self.jwt_source))
     }
 }
 /// Trait for authorizing requests.

--- a/jwt-authorizer/src/layer.rs
+++ b/jwt-authorizer/src/layer.rs
@@ -142,7 +142,7 @@ where
         self
     }
 
-    pub fn with_jwt_source(mut self, src: JwtSource) -> JwtAuthorizer<C> {
+    pub fn jwt_source(mut self, src: JwtSource) -> JwtAuthorizer<C> {
         self.jwt_source = src;
 
         self


### PR DESCRIPTION
Hi there,
I have a use case with [hanko](https://github.com/teamhanko/hanko) where I want to define a cookie as the source for a JWT.
This is a working draft to support this use case.

Do you have any suggestions how this could be improved? I am aware that this might not be the most idiomatic solution.