### PR TITLE
fix(jwt source): cookie from request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,17 +179,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cookie"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7efb37c3e1ccb1ff97164ad95ac1606e8ccd35b3fa0a7d99a304c7f4a428cc24"
-dependencies = [
- "percent-encoding",
- "time",
- "version_check",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,7 +740,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tower",
- "tower-cookies",
  "tower-http",
  "tower-layer",
  "tower-service",
@@ -1570,23 +1558,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tower-cookies"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40f38d941a2ffd8402b36e02ae407637a9caceb693aaf2edc910437db0f36984"
-dependencies = [
- "async-trait",
- "axum-core",
- "cookie",
- "futures-util",
- "http",
- "parking_lot",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]

--- a/jwt-authorizer/Cargo.toml
+++ b/jwt-authorizer/Cargo.toml
@@ -25,7 +25,6 @@ tokio = { version = "1.25", features = ["full"] }
 tower-http = { version = "0.4", features = ["trace", "auth"] }
 tower-layer = "0.3"
 tower-service = "0.3"
-tower-cookies = "0.9.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/jwt-authorizer/src/layer.rs
+++ b/jwt-authorizer/src/layer.rs
@@ -33,7 +33,7 @@ where
     refresh: Option<Refresh>,
     claims_checker: Option<FnClaimsChecker<C>>,
     validation: Option<Validation>,
-    pub jwt_source: JwtSource,
+    jwt_source: JwtSource,
 }
 
 /// authorization layer builder
@@ -48,7 +48,7 @@ where
             refresh: Default::default(),
             claims_checker: None,
             validation: None,
-            jwt_source: JwtSource::Bearer,
+            jwt_source: JwtSource::AuthorizationHeader,
         }
     }
 
@@ -59,7 +59,7 @@ where
             refresh: Default::default(),
             claims_checker: None,
             validation: None,
-            jwt_source: JwtSource::Bearer,
+            jwt_source: JwtSource::AuthorizationHeader,
         }
     }
 
@@ -70,7 +70,7 @@ where
             refresh: Default::default(),
             claims_checker: None,
             validation: None,
-            jwt_source: JwtSource::Bearer,
+            jwt_source: JwtSource::AuthorizationHeader,
         }
     }
 
@@ -81,7 +81,7 @@ where
             refresh: Default::default(),
             claims_checker: None,
             validation: None,
-            jwt_source: JwtSource::Bearer,
+            jwt_source: JwtSource::AuthorizationHeader,
         }
     }
 
@@ -92,7 +92,7 @@ where
             refresh: Default::default(),
             claims_checker: None,
             validation: None,
-            jwt_source: JwtSource::Bearer,
+            jwt_source: JwtSource::AuthorizationHeader,
         }
     }
 
@@ -103,7 +103,7 @@ where
             refresh: Default::default(),
             claims_checker: None,
             validation: None,
-            jwt_source: JwtSource::Bearer,
+            jwt_source: JwtSource::AuthorizationHeader,
         }
     }
 
@@ -114,7 +114,7 @@ where
             refresh: Default::default(),
             claims_checker: None,
             validation: None,
-            jwt_source: JwtSource::Bearer,
+            jwt_source: JwtSource::AuthorizationHeader,
         }
     }
 
@@ -125,7 +125,7 @@ where
             refresh: Default::default(),
             claims_checker: None,
             validation: None,
-            jwt_source: JwtSource::Bearer,
+            jwt_source: JwtSource::AuthorizationHeader,
         }
     }
 
@@ -136,7 +136,7 @@ where
             refresh: Default::default(),
             claims_checker: None,
             validation: None,
-            jwt_source: JwtSource::Bearer,
+            jwt_source: JwtSource::AuthorizationHeader,
         }
     }
 
@@ -175,6 +175,9 @@ where
         self
     }
 
+    /// configures the source of the bearer token
+    ///
+    /// (default: AuthorizationHeader)
     pub fn jwt_source(mut self, src: JwtSource) -> JwtAuthorizer<C> {
         self.jwt_source = src;
 
@@ -214,7 +217,7 @@ where
         let h = request.headers();
 
         let token = match &self.jwt_source {
-            layer::JwtSource::Bearer => {
+            layer::JwtSource::AuthorizationHeader => {
                 let bearer_o: Option<Authorization<Bearer>> = h.typed_get();
                 bearer_o.map(|b| String::from(b.0.token()))
             }
@@ -281,10 +284,19 @@ where
 
 // ----------  AsyncAuthorizationService  --------
 
+/// Source of the bearer token
 #[derive(Clone)]
 pub enum JwtSource {
-    Bearer,
+    /// Storing the bearer token in Authorization header
+    ///
+    /// (default)
+    AuthorizationHeader,
+    /// Cookies
+    ///
+    /// (be careful when using cookies, some precautions must be taken, cf. RFC6750)
     Cookie(String),
+    // TODO: "Form-Encoded Content Parameter" may be added in the future (OAuth 2.1 / 5.2.1.2)
+    // FormParam,
 }
 
 #[derive(Clone)]

--- a/jwt-authorizer/src/layer.rs
+++ b/jwt-authorizer/src/layer.rs
@@ -11,7 +11,6 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
-use tower_cookies::Cookies;
 use tower_layer::Layer;
 use tower_service::Service;
 
@@ -222,8 +221,8 @@ where
                 bearer_o.map(|b| String::from(b.0.token()))
             }
             layer::JwtSource::Cookie(name) => {
-                if let Some(c) = request.extensions().get::<Cookies>() {
-                    c.get(name.as_str()).map(|c| String::from(c.value()))
+                if let Some(c) = h.typed_get::<headers::Cookie>() {
+                    c.get(name.as_str()).map(String::from)
                 } else {
                     tracing::warn!(
                         "You have to add the tower_cookies::CookieManagerLayer middleware to use Cookies as JWT source."

--- a/jwt-authorizer/src/layer.rs
+++ b/jwt-authorizer/src/layer.rs
@@ -220,16 +220,9 @@ where
                 let bearer_o: Option<Authorization<Bearer>> = h.typed_get();
                 bearer_o.map(|b| String::from(b.0.token()))
             }
-            layer::JwtSource::Cookie(name) => {
-                if let Some(c) = h.typed_get::<headers::Cookie>() {
-                    c.get(name.as_str()).map(String::from)
-                } else {
-                    tracing::warn!(
-                        "You have to add the tower_cookies::CookieManagerLayer middleware to use Cookies as JWT source."
-                    );
-                    None
-                }
-            }
+            layer::JwtSource::Cookie(name) => h
+                .typed_get::<headers::Cookie>()
+                .and_then(|c| c.get(name.as_str()).map(String::from)),
         };
         Box::pin(async move {
             if let Some(token) = token {

--- a/jwt-authorizer/tests/integration_tests.rs
+++ b/jwt-authorizer/tests/integration_tests.rs
@@ -9,9 +9,9 @@ use std::{
 };
 
 use axum::{response::Response, routing::get, Json, Router};
-use http::{Request, StatusCode};
+use http::{header::AUTHORIZATION, Request, StatusCode};
 use hyper::Body;
-use jwt_authorizer::{layer::JwtSource, JwtAuthorizer, JwtClaims, Refresh, RefreshStrategy};
+use jwt_authorizer::{JwtAuthorizer, JwtClaims, Refresh, RefreshStrategy};
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -129,7 +129,7 @@ async fn make_proteced_request(app: &mut Router, bearer: &str) -> Response {
         .call(
             Request::builder()
                 .uri("/protected")
-                .header("Authorization", format!("Bearer {bearer}"))
+                .header(AUTHORIZATION.as_str(), format!("Bearer {bearer}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -153,7 +153,6 @@ async fn sequential_tests() {
     scenario2().await;
     scenario3().await;
     scenario4().await;
-    cookie_jwt_source().await;
 }
 
 async fn scenario1() {
@@ -270,29 +269,4 @@ async fn scenario4() {
     let r = make_proteced_request(&mut app, JWT_RSA2_OK).await;
     assert_eq!(StatusCode::UNAUTHORIZED, r.status());
     assert_eq!(1, Stats::jwks_counter());
-}
-
-///  Cookie JWT Source
-///
-async fn cookie_jwt_source() {
-    init_test();
-    let url = run_jwks_server();
-    let auth: JwtAuthorizer<User> = JwtAuthorizer::from_oidc(&url).jwt_source(JwtSource::Cookie("auth_jwt".to_owned()));
-    let mut app = app(auth).await;
-
-    let r = app
-        .ready()
-        .await
-        .unwrap()
-        .call(
-            Request::builder()
-                .uri("/protected")
-                .header(http::header::COOKIE, format!("auth_jwt={}", JWT_RSA1_OK))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(r.status(), StatusCode::OK);
 }


### PR DESCRIPTION
fix(jwt_source): JwtSource::Cookie should take the cookie from request (fixes #9)

- the token cookie should be taken from request not from the tower-cookies middleware jar
- dependency on tower-cookies is not anymore needed