### PR TITLE
feature: Support multiple authorizers

### DIFF
--- a/jwt-authorizer/docs/README.md
+++ b/jwt-authorizer/docs/README.md
@@ -102,5 +102,5 @@ By default the jwks keys are reloaded when a request token is signed with a key 
 - [`JwtAuthorizer::refresh(refresh_configuration)`] allows to define a finer configuration for jwks refreshing, for more details see the documentation of `Refresh` struct.
 
 [`jwt-authorizer::Validation`]: https://docs.rs/jwt-authorizer/latest/jwt_authorizer/validation/struct.Validation.html
-[`JwtAuthorizer::no_refresh()`]: https://docs.rs/jwt-authorizer/latest/jwt_authorizer/layer/struct.JwtAuthorizer.html#method.no_refresh
-[`JwtAuthorizer::refresh(refresh_configuration)`]: https://docs.rs/jwt-authorizer/latest/jwt_authorizer/layer/struct.JwtAuthorizer.html#method.refresh
+[`JwtAuthorizer::no_refresh()`]: https://docs.rs/jwt-authorizer/latest/jwt_authorizer/authorizer/struct.JwtAuthorizer.html#method.no_refresh
+[`JwtAuthorizer::refresh(refresh_configuration)`]: https://docs.rs/jwt-authorizer/latest/jwt_authorizer/authorizer/struct.JwtAuthorizer.html#method.refresh

--- a/jwt-authorizer/src/lib.rs
+++ b/jwt-authorizer/src/lib.rs
@@ -6,9 +6,9 @@ use jsonwebtoken::TokenData;
 use serde::de::DeserializeOwned;
 
 pub use self::error::AuthError;
+pub use authorizer::JwtAuthorizer;
 pub use claims::{NumericDate, RegisteredClaims, StringList};
 pub use jwks::key_store_manager::{Refresh, RefreshStrategy};
-pub use layer::JwtAuthorizer;
 pub use validation::Validation;
 
 pub mod authorizer;

--- a/jwt-authorizer/tests/integration_tests.rs
+++ b/jwt-authorizer/tests/integration_tests.rs
@@ -159,6 +159,7 @@ async fn scenario1() {
     init_test();
     let url = run_jwks_server();
     let auth: JwtAuthorizer<User> = JwtAuthorizer::from_oidc(&url);
+
     let mut app = app(auth).await;
     assert_eq!(1, Stats::discovery_counter());
     assert_eq!(0, Stats::jwks_counter());

--- a/jwt-authorizer/tests/tests.rs
+++ b/jwt-authorizer/tests/tests.rs
@@ -3,6 +3,7 @@ mod common;
 #[cfg(test)]
 mod tests {
     use std::convert::Infallible;
+    use std::sync::Arc;
 
     use axum::{
         body::Body,
@@ -12,7 +13,12 @@ mod tests {
         BoxError, Router,
     };
     use http::{header, HeaderValue};
-    use jwt_authorizer::{layer::JwtSource, validation::Validation, JwtAuthorizer, JwtClaims};
+    use jwt_authorizer::{
+        authorizer::{Authorize, JwtAuthorizer},
+        layer::{AsyncAuthorizationLayer, AsyncAuthorizationLayerBuilder, JwtSource},
+        validation::Validation,
+        JwtClaims,
+    };
     use serde::Deserialize;
     use tower::{util::MapErrLayer, ServiceExt};
 
@@ -23,7 +29,10 @@ mod tests {
         sub: String,
     }
 
-    async fn app(jwt_auth: JwtAuthorizer<User>) -> Router {
+    async fn app<A>(layer: AsyncAuthorizationLayer<A>) -> Router
+    where
+        A: Authorize<Claims = User> + Clone + Send + Sync + 'static,
+    {
         Router::new().route("/public", get(|| async { "hello" })).route(
             "/protected",
             get(|JwtClaims(user): JwtClaims<User>| async move { format!("hello: {}", user.sub) }).layer(
@@ -32,14 +41,21 @@ mod tests {
                         tower::buffer::BufferLayer::new(1),
                         MapErrLayer::new(|e: BoxError| -> Infallible { panic!("{}", e) }),
                     ),
-                    jwt_auth.layer().await.unwrap(),
+                    layer,
                 ),
             ),
         )
     }
 
-    async fn proteced_request_with_header(jwt_auth: JwtAuthorizer<User>, header_name: &str, header_value: &str) -> Response {
-        app(jwt_auth)
+    async fn proteced_request_with_header<A>(
+        auth: AsyncAuthorizationLayer<A>,
+        header_name: &str,
+        header_value: &str,
+    ) -> Response
+    where
+        A: Authorize<Claims = User> + Clone + 'static,
+    {
+        app(auth)
             .await
             .oneshot(
                 Request::builder()
@@ -52,15 +68,21 @@ mod tests {
             .unwrap()
     }
 
-    async fn make_proteced_request(jwt_auth: JwtAuthorizer<User>, bearer: &str) -> Response {
-        proteced_request_with_header(jwt_auth, "Authorization", &format!("Bearer {bearer}")).await
+    async fn make_proteced_request<A>(auth: AsyncAuthorizationLayer<A>, bearer: &str) -> Response
+    where
+        A: Authorize<Claims = User> + Clone + Send + Sync + 'static,
+    {
+        proteced_request_with_header(auth, "Authorization", &format!("Bearer {bearer}")).await
     }
 
     #[tokio::test]
     async fn protected_without_jwt() {
-        let jwt_auth: JwtAuthorizer<User> = JwtAuthorizer::from_rsa_pem("../config/rsa-public1.pem");
+        let layer = JwtAuthorizer::from_rsa_pem("../config/rsa-public1.pem")
+            .layer()
+            .await
+            .unwrap();
 
-        let response = app(jwt_auth)
+        let response = app(layer)
             .await
             .oneshot(Request::builder().uri("/protected").body(Body::empty()).unwrap())
             .await
@@ -79,7 +101,10 @@ mod tests {
     #[tokio::test]
     async fn protected_with_jwt() {
         let response = make_proteced_request(
-            JwtAuthorizer::from_ed_pem("../config/ed25519-public2.pem"),
+            JwtAuthorizer::from_ed_pem("../config/ed25519-public2.pem")
+                .layer()
+                .await
+                .unwrap(),
             common::JWT_ED2_OK,
         )
         .await;
@@ -87,14 +112,26 @@ mod tests {
         let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
         assert_eq!(&body[..], b"hello: b@b.com");
 
-        let response =
-            make_proteced_request(JwtAuthorizer::from_ec_pem("../config/ecdsa-public2.pem"), common::JWT_EC2_OK).await;
+        let response = make_proteced_request(
+            JwtAuthorizer::from_ec_pem("../config/ecdsa-public2.pem")
+                .layer()
+                .await
+                .unwrap(),
+            common::JWT_EC2_OK,
+        )
+        .await;
         assert_eq!(response.status(), StatusCode::OK);
         let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
         assert_eq!(&body[..], b"hello: b@b.com");
 
-        let response =
-            make_proteced_request(JwtAuthorizer::from_rsa_pem("../config/rsa-public2.pem"), common::JWT_RSA2_OK).await;
+        let response = make_proteced_request(
+            JwtAuthorizer::from_rsa_pem("../config/rsa-public2.pem")
+                .layer()
+                .await
+                .unwrap(),
+            common::JWT_RSA2_OK,
+        )
+        .await;
         assert_eq!(response.status(), StatusCode::OK);
         let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
         assert_eq!(&body[..], b"hello: b@b.com");
@@ -102,7 +139,14 @@ mod tests {
 
     #[tokio::test]
     async fn protected_with_bad_jwt() {
-        let response = make_proteced_request(JwtAuthorizer::from_rsa_pem("../config/rsa-public1.pem"), "xxx.xxx.xxx").await;
+        let response = make_proteced_request(
+            JwtAuthorizer::from_rsa_pem("../config/rsa-public1.pem")
+                .layer()
+                .await
+                .unwrap(),
+            "xxx.xxx.xxx",
+        )
+        .await;
 
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
         // TODO: check error code (https://datatracker.ietf.org/doc/html/rfc6750#section-3.1)
@@ -111,7 +155,11 @@ mod tests {
     #[tokio::test]
     async fn protected_with_claims_check() {
         let rsp_ok = make_proteced_request(
-            JwtAuthorizer::from_rsa_pem("../config/rsa-public2.pem").check(|_| true),
+            JwtAuthorizer::from_rsa_pem("../config/rsa-public2.pem")
+                .check(|_| true)
+                .layer()
+                .await
+                .unwrap(),
             common::JWT_RSA2_OK,
         )
         .await;
@@ -119,7 +167,11 @@ mod tests {
         assert_eq!(rsp_ok.status(), StatusCode::OK);
 
         let rsp_ko = make_proteced_request(
-            JwtAuthorizer::from_rsa_pem("../config/rsa-public2.pem").check(|_| false),
+            JwtAuthorizer::from_rsa_pem("../config/rsa-public2.pem")
+                .check(|_| false)
+                .layer()
+                .await
+                .unwrap(),
             common::JWT_RSA2_OK,
         )
         .await;
@@ -139,8 +191,11 @@ mod tests {
     // but should be 500 when checking.
     #[tokio::test]
     async fn protected_with_bad_jwks_url() {
-        let response =
-            make_proteced_request(JwtAuthorizer::from_jwks_url("http://bad-url/xxx/yyy"), common::JWT_RSA1_OK).await;
+        let response = make_proteced_request(
+            JwtAuthorizer::from_jwks_url("http://bad-url/xxx/yyy").layer().await.unwrap(),
+            common::JWT_RSA1_OK,
+        )
+        .await;
 
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
@@ -165,14 +220,22 @@ mod tests {
     #[tokio::test]
     async fn validate_signature() {
         let response = make_proteced_request(
-            JwtAuthorizer::from_rsa_pem("../config/rsa-public1.pem").validation(Validation::new().disable_validation()),
+            JwtAuthorizer::from_rsa_pem("../config/rsa-public1.pem")
+                .validation(Validation::new().disable_validation())
+                .layer()
+                .await
+                .unwrap(),
             common::JWT_EC2_OK,
         )
         .await;
         assert_eq!(response.status(), StatusCode::OK);
 
         let response = make_proteced_request(
-            JwtAuthorizer::from_rsa_pem("../config/rsa-public1.pem").validation(Validation::new()),
+            JwtAuthorizer::from_rsa_pem("../config/rsa-public1.pem")
+                .validation(Validation::new())
+                .layer()
+                .await
+                .unwrap(),
             common::JWT_EC2_OK,
         )
         .await;
@@ -182,14 +245,22 @@ mod tests {
     #[tokio::test]
     async fn validate_iss() {
         let response = make_proteced_request(
-            JwtAuthorizer::from_ec_pem("../config/ecdsa-public1.pem").validation(Validation::new().iss(&["bad-iss"])),
+            JwtAuthorizer::from_ec_pem("../config/ecdsa-public1.pem")
+                .validation(Validation::new().iss(&["bad-iss"]))
+                .layer()
+                .await
+                .unwrap(),
             common::JWT_EC1_OK,
         )
         .await;
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 
         let response = make_proteced_request(
-            JwtAuthorizer::from_ec_pem("../config/ecdsa-public1.pem").validation(Validation::new()),
+            JwtAuthorizer::from_ec_pem("../config/ecdsa-public1.pem")
+                .validation(Validation::new())
+                .layer()
+                .await
+                .unwrap(),
             common::JWT_EC1_OK,
         )
         .await;
@@ -197,7 +268,10 @@ mod tests {
 
         let response = make_proteced_request(
             JwtAuthorizer::from_ec_pem("../config/ecdsa-public1.pem")
-                .validation(Validation::new().iss(&["http://localhost:3001"])),
+                .validation(Validation::new().iss(&["http://localhost:3001"]))
+                .layer()
+                .await
+                .unwrap(),
             common::JWT_EC1_OK,
         )
         .await;
@@ -207,21 +281,33 @@ mod tests {
     #[tokio::test]
     async fn validate_aud() {
         let response = make_proteced_request(
-            JwtAuthorizer::from_ed_pem("../config/ed25519-public1.pem").validation(Validation::new().aud(&["bad-aud"])),
+            JwtAuthorizer::from_ed_pem("../config/ed25519-public1.pem")
+                .validation(Validation::new().aud(&["bad-aud"]))
+                .layer()
+                .await
+                .unwrap(),
             common::JWT_ED1_OK,
         )
         .await;
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 
         let response = make_proteced_request(
-            JwtAuthorizer::from_ed_pem("../config/ed25519-public1.pem").validation(Validation::new()),
+            JwtAuthorizer::from_ed_pem("../config/ed25519-public1.pem")
+                .validation(Validation::new())
+                .layer()
+                .await
+                .unwrap(),
             common::JWT_ED1_OK,
         )
         .await;
         assert_eq!(response.status(), StatusCode::OK);
 
         let response = make_proteced_request(
-            JwtAuthorizer::from_ed_pem("../config/ed25519-public1.pem").validation(Validation::new().aud(&["aud1"])),
+            JwtAuthorizer::from_ed_pem("../config/ed25519-public1.pem")
+                .validation(Validation::new().aud(&["aud1"]))
+                .layer()
+                .await
+                .unwrap(),
             common::JWT_ED1_OK,
         )
         .await;
@@ -232,7 +318,11 @@ mod tests {
     async fn validate_exp() {
         // DEFAULT -> ENABLED
         let response = make_proteced_request(
-            JwtAuthorizer::from_ec_pem("../config/ecdsa-public1.pem").validation(Validation::new()),
+            JwtAuthorizer::from_ec_pem("../config/ecdsa-public1.pem")
+                .validation(Validation::new())
+                .layer()
+                .await
+                .unwrap(),
             common::JWT_EC1_EXP_KO,
         )
         .await;
@@ -240,7 +330,11 @@ mod tests {
 
         // DISABLED
         let response = make_proteced_request(
-            JwtAuthorizer::from_ec_pem("../config/ecdsa-public1.pem").validation(Validation::new().exp(false)),
+            JwtAuthorizer::from_ec_pem("../config/ecdsa-public1.pem")
+                .validation(Validation::new().exp(false))
+                .layer()
+                .await
+                .unwrap(),
             common::JWT_EC1_EXP_KO,
         )
         .await;
@@ -248,13 +342,21 @@ mod tests {
 
         // ENABLED
         let response = make_proteced_request(
-            JwtAuthorizer::from_ec_pem("../config/ecdsa-public1.pem").validation(Validation::new().exp(true)),
+            JwtAuthorizer::from_ec_pem("../config/ecdsa-public1.pem")
+                .validation(Validation::new().exp(true))
+                .layer()
+                .await
+                .unwrap(),
             common::JWT_EC1_EXP_KO,
         )
         .await;
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
         let response = make_proteced_request(
-            JwtAuthorizer::from_ec_pem("../config/ecdsa-public1.pem").validation(Validation::new().exp(true)),
+            JwtAuthorizer::from_ec_pem("../config/ecdsa-public1.pem")
+                .validation(Validation::new().exp(true))
+                .layer()
+                .await
+                .unwrap(),
             common::JWT_EC1_OK,
         )
         .await;
@@ -265,7 +367,11 @@ mod tests {
     async fn validate_nbf() {
         // DEFAULT -> DISABLED
         let response = make_proteced_request(
-            JwtAuthorizer::from_ec_pem("../config/ecdsa-public1.pem").validation(Validation::new()),
+            JwtAuthorizer::from_ec_pem("../config/ecdsa-public1.pem")
+                .validation(Validation::new())
+                .layer()
+                .await
+                .unwrap(),
             common::JWT_EC1_NBF_KO,
         )
         .await;
@@ -273,7 +379,11 @@ mod tests {
 
         // DISABLED
         let response = make_proteced_request(
-            JwtAuthorizer::from_ec_pem("../config/ecdsa-public1.pem").validation(Validation::new().nbf(false)),
+            JwtAuthorizer::from_ec_pem("../config/ecdsa-public1.pem")
+                .validation(Validation::new().nbf(false))
+                .layer()
+                .await
+                .unwrap(),
             common::JWT_EC1_NBF_KO,
         )
         .await;
@@ -281,14 +391,22 @@ mod tests {
 
         // ENABLED
         let response = make_proteced_request(
-            JwtAuthorizer::from_ec_pem("../config/ecdsa-public1.pem").validation(Validation::new().nbf(true)),
+            JwtAuthorizer::from_ec_pem("../config/ecdsa-public1.pem")
+                .validation(Validation::new().nbf(true))
+                .layer()
+                .await
+                .unwrap(),
             common::JWT_EC1_NBF_KO,
         )
         .await;
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 
         let response = make_proteced_request(
-            JwtAuthorizer::from_ec_pem("../config/ecdsa-public1.pem").validation(Validation::new().nbf(true)),
+            JwtAuthorizer::from_ec_pem("../config/ecdsa-public1.pem")
+                .validation(Validation::new().nbf(true))
+                .layer()
+                .await
+                .unwrap(),
             common::JWT_EC1_OK,
         )
         .await;
@@ -302,7 +420,12 @@ mod tests {
     async fn jwt_source_cookie() {
         // OK
         let response = proteced_request_with_header(
-            JwtAuthorizer::from_rsa_pem("../config/rsa-public1.pem").jwt_source(JwtSource::Cookie("ccc".to_owned())),
+            JwtAuthorizer::from_rsa_pem("../config/rsa-public1.pem")
+                .layer_builder()
+                .await
+                .unwrap()
+                .jwt_source(JwtSource::Cookie("ccc".to_owned()))
+                .build(),
             header::COOKIE.as_str(),
             &format!("ccc={}", common::JWT_RSA1_OK),
         )
@@ -311,7 +434,12 @@ mod tests {
 
         // Cookie missing
         let response = proteced_request_with_header(
-            JwtAuthorizer::from_rsa_pem("../config/rsa-public1.pem").jwt_source(JwtSource::Cookie("ccc".to_owned())),
+            JwtAuthorizer::from_rsa_pem("../config/rsa-public1.pem")
+                .layer_builder()
+                .await
+                .unwrap()
+                .jwt_source(JwtSource::Cookie("ccc".to_owned()))
+                .build(),
             header::COOKIE.as_str(),
             &format!("bad_cookie={}", common::JWT_EC2_OK),
         )
@@ -321,7 +449,12 @@ mod tests {
 
         // Invalid Token
         let response = proteced_request_with_header(
-            JwtAuthorizer::from_rsa_pem("../config/rsa-public1.pem").jwt_source(JwtSource::Cookie("ccc".to_owned())),
+            JwtAuthorizer::from_rsa_pem("../config/rsa-public1.pem")
+                .layer_builder()
+                .await
+                .unwrap()
+                .jwt_source(JwtSource::Cookie("ccc".to_owned()))
+                .build(),
             header::COOKIE.as_str(),
             &format!("ccc={}", common::JWT_EC2_OK),
         )
@@ -331,5 +464,29 @@ mod tests {
             response.headers().get(header::WWW_AUTHENTICATE).unwrap(),
             &"Bearer error=\"invalid_token\""
         );
+    }
+
+    #[tokio::test]
+    async fn multiple_key_sources() {
+        let auths = Arc::new([
+            JwtAuthorizer::from_ed_pem("../config/ed25519-public1.pem")
+                .build()
+                .await
+                .unwrap(),
+            JwtAuthorizer::from_ec_pem("../config/ecdsa-public2.pem")
+                .build()
+                .await
+                .unwrap(),
+        ]);
+
+        let layer = AsyncAuthorizationLayerBuilder::new(auths).build();
+        let response = make_proteced_request(layer.clone(), common::JWT_ED1_OK).await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let response = make_proteced_request(layer.clone(), common::JWT_EC2_OK).await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let response = make_proteced_request(layer.clone(), common::JWT_EC1_OK).await;
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 }


### PR DESCRIPTION
This adds a new authorize trait to simply authorize based on a token and refactors the layer to wrap anything implementing this trait. The trait is ofcourse implemented for Authorizer (equivalent to the current code) as well as slices and vectors of Authorizers (or really anything implement authorize) enabling the use of multiple authorities.

To support creating authorizers the main builder is split up into a builder for authorize (to create one or more) and a seperate small one for the layer itself just for the jwt source.

All Authorizers used should be setup for the same claims so a consistent TokenData can be passed down.

Fixes: #14