### PR TITLE
feat: multiple authorizers 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.11 (2023-xx-xx)
+
+- support for multiple authorizers
+  - JwtAuthorizer.layer() deprecated in favor of JwtAuthorizer.into_layer()
+
 ## 0.10.1 (2023-07-11)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.11 (2023-xx-xx)
 
 - support for multiple authorizers
-  - JwtAuthorizer.layer() deprecated in favor of JwtAuthorizer.into_layer()
+  - JwtAuthorizer::layer() deprecated in favor of JwtAuthorizer::build() and IntoLayer::into_layer()
 
 ## 0.10.1 (2023-07-11)
 

--- a/demo-server/src/main.rs
+++ b/demo-server/src/main.rs
@@ -1,5 +1,7 @@
 use axum::{routing::get, Router};
-use jwt_authorizer::{error::InitError, AuthError, IntoLayer, JwtAuthorizer, JwtClaims, Refresh, RefreshStrategy};
+use jwt_authorizer::{
+    error::InitError, AuthError, Authorizer, IntoLayer, JwtAuthorizer, JwtClaims, Refresh, RefreshStrategy,
+};
 use serde::Deserialize;
 use std::net::SocketAddr;
 use tower_http::trace::TraceLayer;
@@ -37,19 +39,21 @@ async fn main() -> Result<(), InitError> {
     // First let's create an authorizer builder from a Oidc Discovery
     // User is a struct deserializable from JWT claims representing the authorized user
     // let jwt_auth: JwtAuthorizer<User> = JwtAuthorizer::from_oidc("https://accounts.google.com/")
-    let jwt_auth: JwtAuthorizer<User> = JwtAuthorizer::from_oidc(issuer_uri)
+    let auth: Authorizer<User> = JwtAuthorizer::from_oidc(issuer_uri)
         // .no_refresh()
         .refresh(Refresh {
             strategy: RefreshStrategy::Interval,
             ..Default::default()
         })
-        .check(claim_checker);
+        .check(claim_checker)
+        .build()
+        .await?;
 
     // actual router demo
     let api = Router::new()
         .route("/protected", get(protected))
         // adding the authorizer layer
-        .layer(jwt_auth.into_layer().await?);
+        .layer(auth.into_layer());
 
     let app = Router::new()
         // public endpoint

--- a/demo-server/src/main.rs
+++ b/demo-server/src/main.rs
@@ -1,5 +1,7 @@
 use axum::{routing::get, Router};
-use jwt_authorizer::{error::InitError, AuthError, JwtAuthorizer, JwtClaims, Refresh, RefreshStrategy};
+use jwt_authorizer::{
+    error::InitError, AuthError, JwtAuthorizer, JwtClaims, Refresh, RefreshStrategy, ToAuthorizationLayer,
+};
 use serde::Deserialize;
 use std::net::SocketAddr;
 use tower_http::trace::TraceLayer;
@@ -49,7 +51,7 @@ async fn main() -> Result<(), InitError> {
     let api = Router::new()
         .route("/protected", get(protected))
         // adding the authorizer layer
-        .layer(jwt_auth.layer().await?);
+        .layer(jwt_auth.to_layer().await?);
 
     let app = Router::new()
         // public endpoint

--- a/demo-server/src/main.rs
+++ b/demo-server/src/main.rs
@@ -1,7 +1,5 @@
 use axum::{routing::get, Router};
-use jwt_authorizer::{
-    error::InitError, AuthError, JwtAuthorizer, JwtClaims, Refresh, RefreshStrategy, ToAuthorizationLayer,
-};
+use jwt_authorizer::{error::InitError, AuthError, IntoLayer, JwtAuthorizer, JwtClaims, Refresh, RefreshStrategy};
 use serde::Deserialize;
 use std::net::SocketAddr;
 use tower_http::trace::TraceLayer;
@@ -51,7 +49,7 @@ async fn main() -> Result<(), InitError> {
     let api = Router::new()
         .route("/protected", get(protected))
         // adding the authorizer layer
-        .layer(jwt_auth.to_layer().await?);
+        .layer(jwt_auth.into_layer().await?);
 
     let app = Router::new()
         // public endpoint

--- a/jwt-authorizer/docs/README.md
+++ b/jwt-authorizer/docs/README.md
@@ -14,12 +14,14 @@ JWT authoriser Layer for Axum and Tonic.
 - Claims extraction
 - Claims checker
 - Tracing support (error logging)
+- *tonic* support
+- multiple authorizers
 
 
 ## Usage Example
 
 ```rust
-# use jwt_authorizer::{AuthError, JwtAuthorizer, JwtClaims, RegisteredClaims};
+# use jwt_authorizer::{AuthError, IntoLayer, JwtAuthorizer, JwtClaims, RegisteredClaims};
 # use axum::{routing::get, Router};
 # use serde::Deserialize;
 
@@ -32,7 +34,7 @@ JWT authoriser Layer for Axum and Tonic.
 
     // adding the authorization layer
     let app = Router::new().route("/protected", get(protected))
-            .layer(jwt_auth.layer().await.unwrap());
+            .layer(jwt_auth.into_layer().await.unwrap());
 
     // proteced handler with user injection (mapping some jwt claims)
     async fn protected(JwtClaims(user): JwtClaims<RegisteredClaims>) -> Result<String, AuthError> {

--- a/jwt-authorizer/docs/README.md
+++ b/jwt-authorizer/docs/README.md
@@ -47,6 +47,11 @@ JWT authoriser Layer for Axum and Tonic.
 # };
 ```
 
+## Multiple Authorizers
+
+A layer can be built using multiple authorizers (`IntoLayer` is implemented for `[Authorizer<C>; N]` and for `Vec<Authorizer<C>>`).
+The authorizers are sequentially applied until one of them validates the token. If no authorizer validates it the request is rejected.
+
 ## Validation
 
 Validation configuration object.

--- a/jwt-authorizer/docs/README.md
+++ b/jwt-authorizer/docs/README.md
@@ -21,7 +21,7 @@ JWT authoriser Layer for Axum and Tonic.
 ## Usage Example
 
 ```rust
-# use jwt_authorizer::{AuthError, IntoLayer, JwtAuthorizer, JwtClaims, RegisteredClaims};
+# use jwt_authorizer::{AuthError, Authorizer, JwtAuthorizer, JwtClaims, RegisteredClaims, IntoLayer};
 # use axum::{routing::get, Router};
 # use serde::Deserialize;
 
@@ -29,12 +29,12 @@ JWT authoriser Layer for Axum and Tonic.
 
     // let's create an authorizer builder from a JWKS Endpoint
     // (a serializable struct can be used to represent jwt claims, JwtAuthorizer<RegisteredClaims> is the default)
-    let jwt_auth: JwtAuthorizer =
-                    JwtAuthorizer::from_jwks_url("http://localhost:3000/oidc/jwks");
+    let auth: Authorizer =
+                    JwtAuthorizer::from_jwks_url("http://localhost:3000/oidc/jwks").build().await.unwrap();
 
     // adding the authorization layer
     let app = Router::new().route("/protected", get(protected))
-            .layer(jwt_auth.into_layer().await.unwrap());
+            .layer(auth.into_layer());
 
     // proteced handler with user injection (mapping some jwt claims)
     async fn protected(JwtClaims(user): JwtClaims<RegisteredClaims>) -> Result<String, AuthError> {

--- a/jwt-authorizer/src/authorizer.rs
+++ b/jwt-authorizer/src/authorizer.rs
@@ -65,7 +65,7 @@ where
     C: DeserializeOwned + Clone + Send + Sync,
 {
     pub(crate) async fn build(
-        key_source_type: &KeySourceType,
+        key_source_type: KeySourceType,
         claims_checker: Option<FnClaimsChecker<C>>,
         refresh: Option<Refresh>,
         validation: crate::validation::Validation,
@@ -157,7 +157,7 @@ where
             }
             KeySourceType::JwksString(jwks_str) => {
                 // TODO: expose it in JwtAuthorizer or remove
-                let set: JwkSet = serde_json::from_str(jwks_str)?;
+                let set: JwkSet = serde_json::from_str(jwks_str.as_str())?;
                 // TODO: replace [0] by kid/alg search
                 let k = KeyData::from_jwk(&set.keys[0]).map_err(InitError::KeyDecodingError)?;
                 Authorizer {
@@ -167,7 +167,7 @@ where
                 }
             }
             KeySourceType::Jwks(url) => {
-                let jwks_url = Url::parse(url).map_err(|e| InitError::JwksUrlError(e.to_string()))?;
+                let jwks_url = Url::parse(url.as_str()).map_err(|e| InitError::JwksUrlError(e.to_string()))?;
                 let key_store_manager = KeyStoreManager::new(jwks_url, refresh.unwrap_or_default());
                 Authorizer {
                     key_source: KeySource::KeyStoreSource(key_store_manager),
@@ -176,7 +176,7 @@ where
                 }
             }
             KeySourceType::Discovery(issuer_url) => {
-                let jwks_url = Url::parse(&oidc::discover_jwks(issuer_url).await?)
+                let jwks_url = Url::parse(&oidc::discover_jwks(issuer_url.as_str()).await?)
                     .map_err(|e| InitError::JwksUrlError(e.to_string()))?;
 
                 let key_store_manager = KeyStoreManager::new(jwks_url, refresh.unwrap_or_default());
@@ -219,7 +219,7 @@ mod tests {
     #[tokio::test]
     async fn build_from_secret() {
         let h = Header::new(Algorithm::HS256);
-        let a = Authorizer::<Value>::build(&KeySourceType::Secret("xxxxxx".to_owned()), None, None, Validation::new())
+        let a = Authorizer::<Value>::build(KeySourceType::Secret("xxxxxx".to_owned()), None, None, Validation::new())
             .await
             .unwrap();
         let k = a.key_source.get_key(h);
@@ -238,7 +238,7 @@ mod tests {
                     "e": "AQAB"
                 }]}
         "#;
-        let a = Authorizer::<Value>::build(&KeySourceType::JwksString(jwks.to_owned()), None, None, Validation::new())
+        let a = Authorizer::<Value>::build(KeySourceType::JwksString(jwks.to_owned()), None, None, Validation::new())
             .await
             .unwrap();
         let k = a.key_source.get_key(Header::new(Algorithm::RS256));
@@ -248,7 +248,7 @@ mod tests {
     #[tokio::test]
     async fn build_from_file() {
         let a = Authorizer::<Value>::build(
-            &KeySourceType::RSA("../config/rsa-public1.pem".to_owned()),
+            KeySourceType::RSA("../config/rsa-public1.pem".to_owned()),
             None,
             None,
             Validation::new(),
@@ -259,7 +259,7 @@ mod tests {
         assert!(k.await.is_ok());
 
         let a = Authorizer::<Value>::build(
-            &KeySourceType::EC("../config/ecdsa-public1.pem".to_owned()),
+            KeySourceType::EC("../config/ecdsa-public1.pem".to_owned()),
             None,
             None,
             Validation::new(),
@@ -270,7 +270,7 @@ mod tests {
         assert!(k.await.is_ok());
 
         let a = Authorizer::<Value>::build(
-            &KeySourceType::ED("../config/ed25519-public1.pem".to_owned()),
+            KeySourceType::ED("../config/ed25519-public1.pem".to_owned()),
             None,
             None,
             Validation::new(),
@@ -284,7 +284,7 @@ mod tests {
     #[tokio::test]
     async fn build_from_text() {
         let a = Authorizer::<Value>::build(
-            &KeySourceType::RSAString(include_str!("../../config/rsa-public1.pem").to_owned()),
+            KeySourceType::RSAString(include_str!("../../config/rsa-public1.pem").to_owned()),
             None,
             None,
             Validation::new(),
@@ -295,7 +295,7 @@ mod tests {
         assert!(k.await.is_ok());
 
         let a = Authorizer::<Value>::build(
-            &KeySourceType::ECString(include_str!("../../config/ecdsa-public1.pem").to_owned()),
+            KeySourceType::ECString(include_str!("../../config/ecdsa-public1.pem").to_owned()),
             None,
             None,
             Validation::new(),
@@ -306,7 +306,7 @@ mod tests {
         assert!(k.await.is_ok());
 
         let a = Authorizer::<Value>::build(
-            &KeySourceType::EDString(include_str!("../../config/ed25519-public1.pem").to_owned()),
+            KeySourceType::EDString(include_str!("../../config/ed25519-public1.pem").to_owned()),
             None,
             None,
             Validation::new(),
@@ -320,7 +320,7 @@ mod tests {
     #[tokio::test]
     async fn build_file_errors() {
         let a = Authorizer::<Value>::build(
-            &KeySourceType::RSA("./config/does-not-exist.pem".to_owned()),
+            KeySourceType::RSA("./config/does-not-exist.pem".to_owned()),
             None,
             None,
             Validation::new(),
@@ -333,7 +333,7 @@ mod tests {
     #[tokio::test]
     async fn build_jwks_url_error() {
         let a =
-            Authorizer::<Value>::build(&KeySourceType::Jwks("://xxxx".to_owned()), None, None, Validation::default()).await;
+            Authorizer::<Value>::build(KeySourceType::Jwks("://xxxx".to_owned()), None, None, Validation::default()).await;
         println!("{:?}", a.as_ref().err());
         assert!(a.is_err());
     }
@@ -341,7 +341,7 @@ mod tests {
     #[tokio::test]
     async fn build_discovery_url_error() {
         let a = Authorizer::<Value>::build(
-            &KeySourceType::Discovery("://xxxx".to_owned()),
+            KeySourceType::Discovery("://xxxx".to_owned()),
             None,
             None,
             Validation::default(),

--- a/jwt-authorizer/src/error.rs
+++ b/jwt-authorizer/src/error.rs
@@ -55,6 +55,9 @@ pub enum AuthError {
 
     #[error("Invalid Claim")]
     InvalidClaims(),
+
+    #[error("No Authorizer")]
+    NoAuthorizer(),
 }
 
 fn response_wwwauth(status: StatusCode, bearer: &str) -> Response<BoxBody> {
@@ -165,6 +168,10 @@ impl IntoResponse for AuthError {
             AuthError::InvalidClaims() => {
                 debug!("AuthErrors::InvalidClaims");
                 response_wwwauth(StatusCode::FORBIDDEN, "error=\"insufficient_scope\"")
+            }
+            AuthError::NoAuthorizer() => {
+                debug!("AuthErrors::NoAuthorizer");
+                response_wwwauth(StatusCode::FORBIDDEN, "error=\"invalid_token\"")
             }
         }
     }

--- a/jwt-authorizer/src/error.rs
+++ b/jwt-authorizer/src/error.rs
@@ -116,6 +116,10 @@ impl From<AuthError> for Response<tonic::body::BoxBody> {
                 debug!("AuthErrors::InvalidClaims");
                 tonic::Status::unauthenticated("error=\"insufficient_scope\"")
             }
+            AuthError::NoAuthorizer() => {
+                debug!("AuthErrors::NoAuthorizer");
+                tonic::Status::unauthenticated("error=\"invalid_token\"")
+            }
         }
         .to_http()
     }

--- a/jwt-authorizer/src/layer.rs
+++ b/jwt-authorizer/src/layer.rs
@@ -209,8 +209,9 @@ where
 }
 
 #[async_trait]
-impl<C> IntoLayer<C> for Vec<JwtAuthorizer<C>>
+impl<C, T> IntoLayer<C> for T
 where
+    T: IntoIterator<Item = JwtAuthorizer<C>> + Send + Sync,
     C: Clone + DeserializeOwned + Send + Sync,
 {
     async fn into_layer(self) -> Result<AsyncAuthorizationLayer<C>, InitError> {

--- a/jwt-authorizer/src/layer.rs
+++ b/jwt-authorizer/src/layer.rs
@@ -275,7 +275,7 @@ where
                 .and_then(|c| c.get(name.as_str()).map(String::from)),
         };
 
-        let authorizers: Vec<Arc<Authorizer<C>>> = self.auths.iter().map(|a| a.clone()).collect();
+        let authorizers: Vec<Arc<Authorizer<C>>> = self.auths.iter().cloned().collect();
 
         Box::pin(async move {
             if let Some(token) = token_o {
@@ -292,12 +292,12 @@ where
                         // services down the stack.
                         request.extensions_mut().insert(tdata);
 
-                        return Ok(request);
+                        Ok(request)
                     }
-                    Err(err) => return Err(err), // TODO: error containing all errors (not just the last one)
+                    Err(err) => Err(err), // TODO: error containing all errors (not just the last one)
                 }
             } else {
-                return Err(AuthError::MissingToken());
+                Err(AuthError::MissingToken())
             }
         })
     }
@@ -398,7 +398,7 @@ where
     pub fn new(inner: S, auths: Vec<Arc<Authorizer<C>>>, jwt_source: JwtSource) -> AsyncAuthorizationService<S, C> {
         Self {
             inner,
-            auths: auths,
+            auths,
             jwt_source,
         }
     }

--- a/jwt-authorizer/src/layer.rs
+++ b/jwt-authorizer/src/layer.rs
@@ -461,7 +461,7 @@ mod tests {
     async fn jwt_auth_to_layer() {
         let auth1: JwtAuthorizer = JwtAuthorizer::from_secret("aaa");
         #[allow(deprecated)]
-        let layer = auth1.layer().await;
-        assert!(layer.is_ok());
+        let layer = auth1.layer().await.unwrap();
+        assert_eq!(1, layer.auths.len());
     }
 }

--- a/jwt-authorizer/src/layer.rs
+++ b/jwt-authorizer/src/layer.rs
@@ -217,6 +217,9 @@ where
     type RequestBody = B;
     type Future = BoxFuture<'static, Result<Request<B>, AuthError>>;
 
+    /// The authorizers are sequentially applied (check_auth) until one of them validates the token.
+    /// If no authorizer validates the token the request is rejected.
+    ///
     fn authorize(&self, mut request: Request<B>) -> Self::Future {
         let tkns_auths: Vec<(String, Arc<Authorizer<C>>)> = self
             .auths
@@ -244,7 +247,7 @@ where
 
                     Ok(request)
                 }
-                Err(err) => Err(err), // TODO: error containing all errors (not just the last one)
+                Err(err) => Err(err), // TODO: error containing all errors (not just the last one) or to choose one?
             }
         })
     }

--- a/jwt-authorizer/src/lib.rs
+++ b/jwt-authorizer/src/lib.rs
@@ -8,7 +8,7 @@ use serde::de::DeserializeOwned;
 pub use self::error::AuthError;
 pub use claims::{NumericDate, OneOrArray, RegisteredClaims};
 pub use jwks::key_store_manager::{Refresh, RefreshStrategy};
-pub use layer::{JwtAuthorizer, ToAuthorizationLayer};
+pub use layer::{IntoLayer, JwtAuthorizer};
 pub use validation::Validation;
 
 pub mod authorizer;

--- a/jwt-authorizer/src/lib.rs
+++ b/jwt-authorizer/src/lib.rs
@@ -8,7 +8,7 @@ use serde::de::DeserializeOwned;
 pub use self::error::AuthError;
 pub use claims::{NumericDate, OneOrArray, RegisteredClaims};
 pub use jwks::key_store_manager::{Refresh, RefreshStrategy};
-pub use layer::JwtAuthorizer;
+pub use layer::{JwtAuthorizer, ToAuthorizationLayer};
 pub use validation::Validation;
 
 pub mod authorizer;

--- a/jwt-authorizer/src/lib.rs
+++ b/jwt-authorizer/src/lib.rs
@@ -6,9 +6,10 @@ use jsonwebtoken::TokenData;
 use serde::de::DeserializeOwned;
 
 pub use self::error::AuthError;
+pub use authorizer::{Authorizer, IntoLayer};
 pub use claims::{NumericDate, OneOrArray, RegisteredClaims};
 pub use jwks::key_store_manager::{Refresh, RefreshStrategy};
-pub use layer::{IntoLayer, JwtAuthorizer};
+pub use layer::JwtAuthorizer;
 pub use validation::Validation;
 
 pub mod authorizer;

--- a/jwt-authorizer/tests/integration_tests.rs
+++ b/jwt-authorizer/tests/integration_tests.rs
@@ -104,7 +104,7 @@ async fn app(jwt_auth: JwtAuthorizer<User>) -> Router {
     let protected_route: Router = Router::new()
         .route("/protected", get(protected_handler))
         .route("/protected-with-user", get(protected_with_user))
-        .layer(jwt_auth.into_layer().await.unwrap());
+        .layer(jwt_auth.build().await.unwrap().into_layer());
 
     Router::new().merge(pub_route).merge(protected_route)
 }

--- a/jwt-authorizer/tests/integration_tests.rs
+++ b/jwt-authorizer/tests/integration_tests.rs
@@ -11,7 +11,7 @@ use std::{
 use axum::{response::Response, routing::get, Json, Router};
 use http::{header::AUTHORIZATION, Request, StatusCode};
 use hyper::Body;
-use jwt_authorizer::{JwtAuthorizer, JwtClaims, Refresh, RefreshStrategy};
+use jwt_authorizer::{JwtAuthorizer, JwtClaims, Refresh, RefreshStrategy, ToAuthorizationLayer};
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -104,7 +104,7 @@ async fn app(jwt_auth: JwtAuthorizer<User>) -> Router {
     let protected_route: Router = Router::new()
         .route("/protected", get(protected_handler))
         .route("/protected-with-user", get(protected_with_user))
-        .layer(jwt_auth.layer().await.unwrap());
+        .layer(jwt_auth.to_layer().await.unwrap());
 
     Router::new().merge(pub_route).merge(protected_route)
 }

--- a/jwt-authorizer/tests/integration_tests.rs
+++ b/jwt-authorizer/tests/integration_tests.rs
@@ -11,7 +11,7 @@ use std::{
 use axum::{response::Response, routing::get, Json, Router};
 use http::{header::AUTHORIZATION, Request, StatusCode};
 use hyper::Body;
-use jwt_authorizer::{JwtAuthorizer, JwtClaims, Refresh, RefreshStrategy, ToAuthorizationLayer};
+use jwt_authorizer::{IntoLayer, JwtAuthorizer, JwtClaims, Refresh, RefreshStrategy};
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -104,7 +104,7 @@ async fn app(jwt_auth: JwtAuthorizer<User>) -> Router {
     let protected_route: Router = Router::new()
         .route("/protected", get(protected_handler))
         .route("/protected-with-user", get(protected_with_user))
-        .layer(jwt_auth.to_layer().await.unwrap());
+        .layer(jwt_auth.into_layer().await.unwrap());
 
     Router::new().merge(pub_route).merge(protected_route)
 }

--- a/jwt-authorizer/tests/tests.rs
+++ b/jwt-authorizer/tests/tests.rs
@@ -12,7 +12,7 @@ mod tests {
         BoxError, Router,
     };
     use http::{header, HeaderValue};
-    use jwt_authorizer::{layer::JwtSource, validation::Validation, JwtAuthorizer, JwtClaims};
+    use jwt_authorizer::{layer::JwtSource, validation::Validation, JwtAuthorizer, JwtClaims, ToAuthorizationLayer};
     use serde::Deserialize;
     use tower::{util::MapErrLayer, ServiceExt};
 
@@ -32,7 +32,7 @@ mod tests {
                         tower::buffer::BufferLayer::new(1),
                         MapErrLayer::new(|e: BoxError| -> Infallible { panic!("{}", e) }),
                     ),
-                    jwt_auth.layer().await.unwrap(),
+                    jwt_auth.to_layer().await.unwrap(),
                 ),
             ),
         )

--- a/jwt-authorizer/tests/tests.rs
+++ b/jwt-authorizer/tests/tests.rs
@@ -12,7 +12,7 @@ mod tests {
         BoxError, Router,
     };
     use http::{header, HeaderValue};
-    use jwt_authorizer::{layer::JwtSource, validation::Validation, JwtAuthorizer, JwtClaims, ToAuthorizationLayer};
+    use jwt_authorizer::{layer::JwtSource, validation::Validation, IntoLayer, JwtAuthorizer, JwtClaims};
     use serde::Deserialize;
     use tower::{util::MapErrLayer, ServiceExt};
 
@@ -23,7 +23,7 @@ mod tests {
         sub: String,
     }
 
-    async fn app(jwt_auth: impl ToAuthorizationLayer<User>) -> Router {
+    async fn app(jwt_auth: impl IntoLayer<User>) -> Router {
         Router::new().route("/public", get(|| async { "hello" })).route(
             "/protected",
             get(|JwtClaims(user): JwtClaims<User>| async move { format!("hello: {}", user.sub) }).layer(
@@ -32,14 +32,14 @@ mod tests {
                         tower::buffer::BufferLayer::new(1),
                         MapErrLayer::new(|e: BoxError| -> Infallible { panic!("{}", e) }),
                     ),
-                    jwt_auth.to_layer().await.unwrap(),
+                    jwt_auth.into_layer().await.unwrap(),
                 ),
             ),
         )
     }
 
     async fn proteced_request_with_header(
-        jwt_auth: impl ToAuthorizationLayer<User>,
+        jwt_auth: impl IntoLayer<User>,
         header_name: &str,
         header_value: &str,
     ) -> Response {
@@ -56,7 +56,7 @@ mod tests {
             .unwrap()
     }
 
-    async fn make_proteced_request(jwt_auth: impl ToAuthorizationLayer<User>, bearer: &str) -> Response {
+    async fn make_proteced_request(jwt_auth: impl IntoLayer<User>, bearer: &str) -> Response {
         proteced_request_with_header(jwt_auth, "Authorization", &format!("Bearer {bearer}")).await
     }
 

--- a/jwt-authorizer/tests/tests.rs
+++ b/jwt-authorizer/tests/tests.rs
@@ -352,7 +352,7 @@ mod tests {
             proteced_request_with_header(auths, header::COOKIE.as_str(), &format!("ccc={}", common::JWT_RSA1_OK)).await;
         assert_eq!(response.status(), StatusCode::OK);
 
-        let auths: Vec<JwtAuthorizer<User>> = vec![
+        let auths: [JwtAuthorizer<User>; 2] = [
             JwtAuthorizer::from_ec_pem("../config/ecdsa-public1.pem"),
             JwtAuthorizer::from_rsa_pem("../config/rsa-public1.pem").jwt_source(JwtSource::Cookie("ccc".to_owned())),
         ];

--- a/jwt-authorizer/tests/tonic.rs
+++ b/jwt-authorizer/tests/tonic.rs
@@ -83,7 +83,7 @@ async fn app(
     jwt_auth: JwtAuthorizer<User>,
     expected_sub: String,
 ) -> AsyncAuthorizationService<Buffer<tonic::transport::server::Routes, http::Request<tonic::transport::Body>>, User> {
-    let layer = jwt_auth.into_layer().await.unwrap();
+    let layer = jwt_auth.build().await.unwrap().into_layer();
     tonic::transport::Server::builder()
         .layer(layer)
         .layer(tower::buffer::BufferLayer::new(1))

--- a/jwt-authorizer/tests/tonic.rs
+++ b/jwt-authorizer/tests/tonic.rs
@@ -3,7 +3,7 @@ use std::{sync::Once, task::Poll};
 use axum::body::HttpBody;
 use futures_core::future::BoxFuture;
 use http::header::AUTHORIZATION;
-use jwt_authorizer::{layer::AsyncAuthorizationService, JwtAuthorizer};
+use jwt_authorizer::{layer::AsyncAuthorizationService, IntoLayer, JwtAuthorizer};
 use serde::{Deserialize, Serialize};
 use tonic::{server::UnaryService, transport::NamedService, IntoRequest, Status};
 use tower::{buffer::Buffer, Service};
@@ -83,7 +83,7 @@ async fn app(
     jwt_auth: JwtAuthorizer<User>,
     expected_sub: String,
 ) -> AsyncAuthorizationService<Buffer<tonic::transport::server::Routes, http::Request<tonic::transport::Body>>, User> {
-    let layer = jwt_auth.layer().await.unwrap();
+    let layer = jwt_auth.into_layer().await.unwrap();
     tonic::transport::Server::builder()
         .layer(layer)
         .layer(tower::buffer::BufferLayer::new(1))


### PR DESCRIPTION
Allows to accept token signed by one of multiple issuers.
- building AuthorizationLayer with a vector or a slice of one or more authorizers
- backward compatbility (though JwtAuthorizer::layer is deprecated, and replaced by into_layer())
- tests

fixes: #14