### PR TITLE
Make working with NumericDate a little more convenient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,7 +830,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "time 0.3.21",
+ "time 0.3.22",
 ]
 
 [[package]]
@@ -875,6 +875,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "time 0.3.22",
  "tokio",
  "tonic",
  "tower",
@@ -1638,7 +1639,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror",
- "time 0.3.21",
+ "time 0.3.22",
 ]
 
 [[package]]
@@ -1756,9 +1757,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.21"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
+checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
 dependencies = [
  "itoa",
  "serde",

--- a/jwt-authorizer/Cargo.toml
+++ b/jwt-authorizer/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["jwt","axum","authorisation","jwks"]
 
 [dependencies]
 axum = { version = "0.6", features = ["headers"] }
-chrono = "0.4"
+chrono = { version = "0.4", optional = true }
 futures-util = "0.3"
 futures-core = "0.3"
 headers = "0.3"
@@ -29,6 +29,7 @@ tower-service = "0.3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tonic = { version = "0.9.2", optional = true }
+time = { version = "0.3.22", optional = true }
 
 [dev-dependencies]
 hyper = { version = "0.14", features = ["full"] }
@@ -38,7 +39,7 @@ tower = { version = "0.4", features = ["util", "buffer"] }
 wiremock = "0.5"
 
 [features]
-default = ["default-tls"]
+default = ["default-tls", "chrono"]
 default-tls = ["reqwest/default-tls"]
 native-tls = ["reqwest/native-tls"]
 native-tls-vendored = ["reqwest/native-tls-vendored"]
@@ -47,6 +48,8 @@ rustls-tls = ["reqwest/rustls-tls"]
 rustls-tls-manual-roots = ["reqwest/rustls-tls-manual-roots"]
 rustls-tls-webpki-roots = ["reqwest/rustls-tls-webpki-roots"]
 rustls-tls-native-roots = ["reqwest/rustls-tls-native-roots"]
+time = ["dep:time"]
+chrono = ["dep:chrono"]
 
 [[test]]
 name = "tonic"

--- a/jwt-authorizer/src/claims.rs
+++ b/jwt-authorizer/src/claims.rs
@@ -6,6 +6,13 @@ use serde::{de, Deserialize, Deserializer};
 #[derive(Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct NumericDate(i64);
 
+impl NumericDate {
+    /// Get the underlying unix timestamp
+    pub fn inner(&self) -> i64 {
+        self.0
+    }
+}
+
 #[cfg(feature = "chrono")]
 use chrono::{DateTime, TimeZone, Utc};
 

--- a/jwt-authorizer/src/claims.rs
+++ b/jwt-authorizer/src/claims.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, TimeZone, Utc};
 use std::fmt;
 
 use serde::{de, Deserialize, Deserializer};
@@ -7,9 +6,23 @@ use serde::{de, Deserialize, Deserializer};
 #[derive(Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct NumericDate(i64);
 
+#[cfg(feature = "chrono")]
+use chrono::{DateTime, TimeZone, Utc};
+
+#[cfg(feature = "chrono")]
 impl From<NumericDate> for DateTime<Utc> {
     fn from(t: NumericDate) -> Self {
         Utc.timestamp_opt(t.0, 0).unwrap()
+    }
+}
+
+#[cfg(feature = "time")]
+use time::OffsetDateTime;
+
+#[cfg(feature = "time")]
+impl From<NumericDate> for OffsetDateTime {
+    fn from(t: NumericDate) -> Self {
+        OffsetDateTime::from_unix_timestamp(t.0).unwrap()
     }
 }
 


### PR DESCRIPTION
My motivation for this:
I am using the `time` crate in a project and ran into problems when trying to access the timestamp in the `NumericDate` type.

- Added `time` as an optional dependency with an accompanying feature.
- Made `chrono` an optional dependency with an accompanying feature and also made it a default feature to hopefully not break existing code.
- Added function for accessing the actual timestamp stored in the `NumericDate` type.