### PR TITLE
fix(claims): aud can a string or an array of strings

### DIFF
--- a/jwt-authorizer/src/claims.rs
+++ b/jwt-authorizer/src/claims.rs
@@ -19,6 +19,15 @@ pub enum OneOrArray<T> {
     Array(Vec<T>),
 }
 
+impl<T> OneOrArray<T> {
+    pub fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = &'a T> + 'a> {
+        match self {
+            OneOrArray::One(v) => Box::new(std::iter::once(v)),
+            OneOrArray::Array(vector) => Box::new(vector.iter()),
+        }
+    }
+}
+
 /// Claims mentioned in the JWT specifications.
 ///
 /// https://www.rfc-editor.org/rfc/rfc7519#section-4.1
@@ -45,6 +54,23 @@ mod tests {
     #[derive(Deserialize)]
     struct TestStruct {
         v: OneOrArray<String>,
+    }
+
+    #[test]
+    fn one_or_array_iter() {
+        let o = OneOrArray::One("aaa".to_owned());
+        let mut i = o.iter();
+        assert_eq!(Some(&"aaa".to_owned()), i.next());
+
+        let a = OneOrArray::Array(vec!["aaa".to_owned()]);
+        let mut i = a.iter();
+        assert_eq!(Some(&"aaa".to_owned()), i.next());
+
+        let a = OneOrArray::Array(vec!["aaa".to_owned(), "bbb".to_owned()]);
+        let mut i = a.iter();
+        assert_eq!(Some(&"aaa".to_owned()), i.next());
+        assert_eq!(Some(&"bbb".to_owned()), i.next());
+        assert_eq!(None, i.next());
     }
 
     #[test]

--- a/jwt-authorizer/src/lib.rs
+++ b/jwt-authorizer/src/lib.rs
@@ -6,7 +6,7 @@ use jsonwebtoken::TokenData;
 use serde::de::DeserializeOwned;
 
 pub use self::error::AuthError;
-pub use claims::{NumericDate, RegisteredClaims, StringList};
+pub use claims::{NumericDate, OneOrArray, RegisteredClaims};
 pub use jwks::key_store_manager::{Refresh, RefreshStrategy};
 pub use layer::JwtAuthorizer;
 pub use validation::Validation;


### PR DESCRIPTION
fixes #26

RFC7519: "In the general case, the "aud" value is an **array of case-
sensitive strings**, each containing a StringOrURI value.  In the
special case when the JWT has one audience, the "aud" value MAY be a
**single case-sensitive string** containing a StringOrURI value."