### PR TITLE
Claims checker: closures with variable capture 

### DIFF
--- a/jwt-authorizer/src/authorizer.rs
+++ b/jwt-authorizer/src/authorizer.rs
@@ -20,14 +20,14 @@ pub trait ClaimsChecker<C> {
 #[derive(Clone)]
 pub struct FnClaimsChecker<C>
 where
-    C: Clone,
+    C: Clone + Send + Sync,
 {
-    pub checker_fn: fn(&C) -> bool,
+    pub checker_fn: Arc<Box<dyn Fn(&C) -> bool + Send + Sync>>,
 }
 
 impl<C> ClaimsChecker<C> for FnClaimsChecker<C>
 where
-    C: Clone,
+    C: Clone + Send + Sync,
 {
     fn check(&self, claims: &C) -> bool {
         (self.checker_fn)(claims)
@@ -36,7 +36,7 @@ where
 
 pub struct Authorizer<C = RegisteredClaims>
 where
-    C: Clone,
+    C: Clone + Send,
 {
     pub key_source: KeySource,
     pub claims_checker: Option<FnClaimsChecker<C>>,

--- a/jwt-authorizer/src/builder.rs
+++ b/jwt-authorizer/src/builder.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use serde::de::DeserializeOwned;
 
 use crate::{
-    authorizer::{FnClaimsChecker, KeySourceType},
+    authorizer::{ClaimsCheckerFn, KeySourceType},
     error::InitError,
     layer::{AuthorizationLayer, JwtSource},
     Authorizer, Refresh, RefreshStrategy, RegisteredClaims, Validation,
@@ -19,7 +19,7 @@ where
 {
     key_source_type: KeySourceType,
     refresh: Option<Refresh>,
-    claims_checker: Option<FnClaimsChecker<C>>,
+    claims_checker: Option<ClaimsCheckerFn<C>>,
     validation: Option<Validation>,
     jwt_source: JwtSource,
 }
@@ -158,9 +158,7 @@ where
     where
         F: Fn(&C) -> bool + Send + Sync + 'static,
     {
-        self.claims_checker = Some(FnClaimsChecker {
-            checker_fn: Arc::new(Box::new(checker_fn)),
-        });
+        self.claims_checker = Some(Arc::new(Box::new(checker_fn)));
 
         self
     }

--- a/jwt-authorizer/src/builder.rs
+++ b/jwt-authorizer/src/builder.rs
@@ -154,8 +154,13 @@ where
 
     /// configures token content check (custom function), if false a 403 will be sent.
     /// (AuthError::InvalidClaims())
-    pub fn check(mut self, checker_fn: fn(&C) -> bool) -> AuthorizerBuilder<C> {
-        self.claims_checker = Some(FnClaimsChecker { checker_fn });
+    pub fn check<F>(mut self, checker_fn: F) -> AuthorizerBuilder<C>
+    where
+        F: Fn(&C) -> bool + Send + Sync + 'static,
+    {
+        self.claims_checker = Some(FnClaimsChecker {
+            checker_fn: Arc::new(Box::new(checker_fn)),
+        });
 
         self
     }

--- a/jwt-authorizer/tests/tests.rs
+++ b/jwt-authorizer/tests/tests.rs
@@ -126,8 +126,9 @@ mod tests {
 
     #[tokio::test]
     async fn protected_with_claims_check() {
+        let b = true; // to test closures
         let rsp_ok = make_proteced_request(
-            JwtAuthorizer::from_rsa_pem("../config/rsa-public2.pem").check(|_| true),
+            JwtAuthorizer::from_rsa_pem("../config/rsa-public2.pem").check(move |_| b),
             common::JWT_RSA2_OK,
         )
         .await;


### PR DESCRIPTION
Replaces function pointer by implementation of Fn() for claims checker, allowing thus for variable capture in closures.
Simplification of code. 

fixes #32 