### PR TITLE
Fix aud validation

### DIFF
--- a/jwt-authorizer/src/validation.rs
+++ b/jwt-authorizer/src/validation.rs
@@ -17,10 +17,6 @@ pub struct Validation {
     ///
     /// Defaults to `false`.
     pub validate_nbf: bool,
-    /// Whether to validate the `aud` field.
-    ///
-    /// Defaults to `true`.
-    pub validate_aud: bool,
     /// If it contains a value, the validation will check that the `aud` claim value is in the values provided.
     ///
     /// Defaults to `None`.
@@ -50,14 +46,6 @@ impl Validation {
     /// check that the `iss` claim is a member of the values provided
     pub fn iss<T: ToString>(mut self, items: &[T]) -> Self {
         self.iss = Some(items.iter().map(|x| x.to_string()).collect());
-
-        self
-    }
-
-    /// enables or disables aud validation
-    /// Very insecure to turn that off, only do it if you know what you're doing.
-    pub fn validate_aud(mut self, val: bool) -> Self {
-        self.validate_aud = val;
 
         self
     }
@@ -127,7 +115,7 @@ impl Validation {
         jwt_validation.leeway = self.leeway;
         jwt_validation.validate_exp = self.validate_exp;
         jwt_validation.validate_nbf = self.validate_nbf;
-        jwt_validation.validate_aud = self.validate_aud;
+        jwt_validation.validate_aud = self.aud.is_some();
         jwt_validation.iss = iss;
         jwt_validation.aud = aud;
         jwt_validation.sub = None;
@@ -151,7 +139,6 @@ impl Default for Validation {
 
             validate_exp: true,
             validate_nbf: false,
-            validate_aud: true,
 
             iss: None,
             aud: None,


### PR DESCRIPTION
Currently, actual behavior does not match the docs. 

For `Validation`'s field `aud` it says: "If it contains a value, the validation will check that the `aud` claim value is in the values provided.". Reading this, I assume that it will skip validation of `aud` claim if this option is `None`

But in reality, it will fail for any token if the `aud` is `None` (because of validation logic inside `jsonwebtoken` crate)

This PR fixes it by setting an appropriate option `validate_aud` for validation options of `jsonwebtoken`
